### PR TITLE
add support for `extra_vars` (using `-e`) for the "configure" command

### DIFF
--- a/ploy_ansible/test_ansible.py
+++ b/ploy_ansible/test_ansible.py
@@ -148,6 +148,17 @@ def test_configure_roles_playbook_option_conflict(ctrl, ployconf, caplog, tempdi
         "You can't use a playbook and the 'roles' options at the same time for instance 'dummy-instance:foo'."]
 
 
+def test_configure_with_extra_vars(ctrl, monkeypatch, tempdir):
+    import ansible.playbook
+    tempdir['default-foo.yml'].fill([
+        '---',
+        '- hosts: default-foo'])
+    with patch.object(ansible.playbook.PlayBook, "run", autospec=True) as runmock:
+        ctrl(['./bin/ploy', 'configure', 'foo', '-e', 'foo=bar', '-e', 'bar=foo'])
+    assert runmock.called
+    assert runmock.call_args[0][0].extra_vars == dict(foo='bar', bar='foo')
+
+
 def test_playbook_without_args(ctrl):
     with patch('sys.stderr') as StdErrMock:
         StdErrMock.encoding = 'utf-8'


### PR DESCRIPTION
we want to `ploy configure <target> -e foo=bar` ;)
